### PR TITLE
fix: stop Database Analyzer loop on DOUBLE PRECISION defaults (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ For search functionality enhancement, see [README_SOLR.md](README_SOLR.md).
 - **Theme Analysis Errors**: Verify NlpTools extension is installed
 - **Linkvalidator Not Working**: Ensure cms-linkvalidator scheduler task has been run at least once
 - **Semantic Suggestions Missing**: Install and configure the semantic_suggestion extension
+- **Database Analyzer Loop**: The Database Analyzer (*Admin Tools → Maintenance → Analyze Database*) may keep suggesting the same `ALTER TABLE ... DOUBLE PRECISION` statements for the `weight`/`relevance` columns even after executing them. The cause was a default-value mismatch (`'0.00'` in the schema vs `'0'` stored by MySQL 8.x / MariaDB). This is fixed from this version onwards: the affected columns now use `DEFAULT '0'`, matching the value the database actually stores and the other `DOUBLE PRECISION` columns in the extension. If you upgraded an existing installation, run the Database Analyzer **once** to align your schema; the suggestion will then stop reappearing. See [issue #22](https://github.com/friteuseb/page_link_insights/issues/22).
 
 ## Support and Contribution
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -75,7 +75,7 @@ CREATE TABLE tx_pagelinkinsights_keywords (
     page_uid int(11) DEFAULT '0' NOT NULL,
     keyword varchar(255) DEFAULT '' NOT NULL,
     frequency int(11) DEFAULT '0' NOT NULL,
-    weight DOUBLE PRECISION DEFAULT '0.00' NOT NULL,
+    weight DOUBLE PRECISION DEFAULT '0' NOT NULL,
     language int(11) DEFAULT '0' NOT NULL,
     content_type varchar(50) DEFAULT '' NOT NULL, 
     
@@ -94,7 +94,7 @@ CREATE TABLE tx_pagelinkinsights_themes (
     
     theme_name varchar(255) DEFAULT '' NOT NULL,
     keywords text,
-    weight DOUBLE PRECISION DEFAULT '0.00' NOT NULL,
+    weight DOUBLE PRECISION DEFAULT '0' NOT NULL,
     language int(11) DEFAULT '0' NOT NULL,
     
     PRIMARY KEY (uid),
@@ -111,7 +111,7 @@ CREATE TABLE tx_pagelinkinsights_page_themes (
     
     page_uid int(11) DEFAULT '0' NOT NULL,
     theme_uid int(11) DEFAULT '0' NOT NULL,
-    relevance DOUBLE PRECISION DEFAULT '0.00' NOT NULL,
+    relevance DOUBLE PRECISION DEFAULT '0' NOT NULL,
     
     PRIMARY KEY (uid),
     KEY parent (pid),


### PR DESCRIPTION
## Problème

Le Database Analyzer de TYPO3 (*Admin Tools → Maintenance → Analyze Database*) boucle : il re-propose indéfiniment des `ALTER TABLE ... DOUBLE PRECISION` pour `weight`/`relevance`, même après exécution.

## Cause

Mismatch de valeur par défaut entre le schéma et ce que la base stocke réellement :
- `ext_tables.sql` déclarait `DEFAULT '0.00'`
- MySQL 8.x **et** MariaDB normalisent/introspectent ce défaut en `'0'`

Le comparateur Doctrine DBAL de TYPO3 introspecte le défaut stocké sous forme de chaîne `'0'` → écart permanent → boucle.

⚠️ La piste « `DEFAULT 0` (non quoté) » suggérée à l'origine **ne résout pas** la boucle : testé localement, l'analyseur continuait de réclamer `0` vs `'0'`.

## Correctif

Les trois colonnes passent à **`DEFAULT '0'` (quoté)** — exactement comme les autres colonnes `DOUBLE PRECISION` de l'extension (`pagerank`, `centrality_score`, `network_density`…) qui n'ont **jamais** déclenché la boucle :

- `tx_pagelinkinsights_keywords.weight`
- `tx_pagelinkinsights_themes.weight`
- `tx_pagelinkinsights_page_themes.relevance`

## Vérification

Testé sur **MariaDB 10.11** (TYPO3 13.4) via le `SchemaMigrator` de TYPO3 (le moteur même du Database Analyzer) :
- Avant : 3 changements en attente, persistants même après application des ALTER
- Après : **0 changement en attente**, alerte disparue dans le backend

Couvre aussi le cas MySQL 8.x du rapport, l'engine y stockant également le défaut en `'0'`.

Une note d'upgrade est ajoutée dans le README (section *Troubleshooting*).

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
