### PR TITLE
feat: make system folders (doktype 254) configurable as diagram nodes (#20)

### DIFF
--- a/Classes/Service/PageLinkService.php
+++ b/Classes/Service/PageLinkService.php
@@ -21,6 +21,7 @@ class PageLinkService
     private bool $includeHidden;
     private bool $includeShortcuts;
     private bool $includeExternalLinks;
+    private bool $includeSysFolders;
     private bool $includeSemanticSuggestions;
     private bool $includeSolrRecords;
     private bool $useLinkvalidator;
@@ -40,6 +41,7 @@ class PageLinkService
         $this->includeHidden = (bool)($this->extensionConfiguration['includeHidden'] ?? false);
         $this->includeShortcuts = (bool)($this->extensionConfiguration['includeShortcuts'] ?? false);
         $this->includeExternalLinks = (bool)($this->extensionConfiguration['includeExternalLinks'] ?? false);
+        $this->includeSysFolders = (bool)($this->extensionConfiguration['includeSysFolders'] ?? false);
         $this->includeSemanticSuggestions = (bool)($this->extensionConfiguration['includeSemanticSuggestions'] ?? true);
         $this->includeSolrRecords = (bool)($this->extensionConfiguration['includeSolrRecords'] ?? true);
         $this->useLinkvalidator = (bool)($this->extensionConfiguration['useLinkvalidator'] ?? true);
@@ -48,12 +50,15 @@ class PageLinkService
     private function getExcludedDokTypes(): array
     {
         $excludedDokTypes = [
-            254, // System folders
             255, // Recycler (legacy)
             199  // Menu separators - always exclude as they don't serve content
         ];
 
-        // Conditionally exclude shortcuts and external links
+        // Conditionally exclude system folders, shortcuts and external links
+        if (!$this->includeSysFolders) {
+            $excludedDokTypes[] = 254; // System folders
+        }
+
         if (!$this->includeShortcuts) {
             $excludedDokTypes[] = 4; // Shortcuts
         }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The extension can be configured through the Extension Configuration in TYPO3 Bac
 |--------|---------|-------------|
 | `includeShortcuts` | `false` | Include shortcut pages (doktype 4) in diagrams |
 | `includeExternalLinks` | `false` | Include external link pages (doktype 3) in diagrams |
+| `includeSysFolders` | `false` | Include system folders (doktype 254) as nodes in diagrams. Enable this when sys-folders are used as menu entry points |
+| `includeSolrRecords` | `true` | Include Solr-indexed records (e.g. news) as nodes with More-Like-This links |
 | `useLinkvalidator` | `true` | Use TYPO3 linkvalidator for broken link detection (if available) |
 
 > **Note**: The `useLinkvalidator` option provides more accurate broken link detection when cms-linkvalidator is installed and its scheduler task has been run. If linkvalidator is not available, the extension falls back to checking if target pages exist in the database.

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,6 +13,9 @@ includeShortcuts = 0
 # cat=advanced/enable; type=boolean; label=Include external link pages in diagrams
 includeExternalLinks = 0
 
+# cat=advanced/enable; type=boolean; label=Include system folders (doktype 254) as nodes in diagrams
+includeSysFolders = 0
+
 # cat=advanced/enable; type=boolean; label=Include Solr-indexed records (news) as nodes with MLT links
 includeSolrRecords = 1
 


### PR DESCRIPTION
## Contexte

Issue #20 : sur les grands sites, la structure de menu est souvent organisée avec des **sys-folders (doktype 254)** servant de points d'entrée de menus / méta-menus. Le souhait : pouvoir les afficher comme nœuds dans le diagramme.

Jusqu'ici, le doktype 254 était exclu **en dur** dans `getExcludedDokTypes()`.

## Changement

Ajout d'une option de configuration d'extension **`includeSysFolders`** (défaut `false` → comportement actuel inchangé). Quand elle est activée, le doktype 254 n'est plus exclu et les sys-folders apparaissent comme nœuds — sur le même modèle que les options existantes `includeShortcuts` / `includeExternalLinks`.

- `ext_conf_template.txt` : nouvelle option `includeSysFolders` (advanced)
- `PageLinkService` : propriété + lecture de config + exclusion conditionnelle de 254
- `README.md` : documentation de `includeSysFolders` (et de `includeSolrRecords`, qui n'était pas documentée)

La logique séparée qui repère les sys-folders pour scanner les news qu'ils stockent (`getStorageFolderIds`) **n'est pas affectée**.

## Vérification

Testé via réflexion sur `getExcludedDokTypes()` (TYPO3 13.4) :

| `includeSysFolders` | doktypes exclus | 254 exclu ? |
|---|---|---|
| `0` (défaut) | `255,199,254,4,3` | ✅ oui (inchangé) |
| `1` | `255,199,4,3` | ❌ non (sys-folders affichés) |

`php -l` OK.

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
